### PR TITLE
Make wielditem unpointable

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -74,6 +74,7 @@ end
 
 local wield_entity = {
 	physical = false,
+	pointable = false,
 	collisionbox = {-0.125,-0.125,-0.125, 0.125,0.125,0.125},
 	visual = "wielditem",
 	textures = {"wield3d:hand"},


### PR DESCRIPTION
Not sure if it was intended or not but the wielditem is pointable. This code should fix that.
I haven't tested this. But I can if requested